### PR TITLE
terminal.go: when diffiing, compared based on scores, not string values

### DIFF
--- a/pkg/render/terminal.go
+++ b/pkg/render/terminal.go
@@ -291,10 +291,10 @@ func renderFileSummary(_ context.Context, fr *malcontent.FileReport, w io.Writer
 				diff = color.HiGreenString("+")
 			}
 
-			if riskLevel > previousRiskLevel {
+			if riskScore > previousNsRiskScore[ns]{
 				nsIcon = color.HiYellowString("▲")
 			}
-			if riskLevel < previousRiskLevel {
+			if riskScore < previousNsRiskScore[ns]{
 				nsIcon = color.HiGreenString("▼")
 			}
 			if riskLevel == "NONE" {


### PR DESCRIPTION
The current terminal comparison is based on the string values from the `riskLevels` table in strings.go. This meant NONE -> MEDIUM would get a different ▲ indicator then LOW -> MEDIUM. 

Here is an example snippet based on the current egibs/malcontent branch (i.e. with the inverted logic commit applied):

```
+    ▼ evasion [NONE → MEDIUM]
+      🟡 file/prefix — possible hidden file path: /usr/lib/debug/.dwz
     ≡ execution [LOW]
     ▲ filesystem [LOW → MEDIUM]
+      🟡 path/relative — references and possibly executes relative path: ./epan
```

Note how NONE → MEDIUM gets a ▼, but LOW → MEDIUM gets an ▲. This is because the character `N` (prior level) is greater than `M`, but `L` is less than `M`.

The commit here changes the comparisons to be based on the numeric rank scores rather than the string value representations, which gives the correct ordering:

```
+    ▲ evasion [NONE → MEDIUM]
+      🟡 file/prefix — possible hidden file path: /usr/lib/debug/.dwz
     ≡ execution [LOW]
     ▲ filesystem [LOW → MEDIUM]
+      🟡 path/relative — references and possibly executes relative path: ./epan
```
